### PR TITLE
feat: Upgrade to Zig 0.16.0 with juicy main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.zig-cache
+zig-out
+zig-pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0
     - uses: mlugg/setup-zig@v2
       with:
-        version: 0.15.2
+        version: 0.16.0
     - name: Install dependencies
       run: sudo apt-get install -y build-essential libgit2-dev
     - name: Build
@@ -23,4 +23,4 @@ jobs:
     - name: Test
       run: zig build test --summary all
     - name: Format check
-      run: zig fmt --check .
+      run: zig fmt --check src build.zig build.zig.zon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
 # syntax=docker/dockerfile:1.7
 # check=error=true
-FROM alpine:3.23.3
+FROM alpine:edge
 
-RUN apk add --no-cache build-base \
-    zig libgit2-dev
+ARG ZVM_VERSION=v0.8.20
+ARG ZIG_VERSION=0.16.0
+
+ENV GOBIN=/usr/local/bin
+ENV PATH=/root/.zvm/bin:${PATH}
+
+RUN apk add --no-cache build-base libgit2-dev go \
+    && go install github.com/tristanisham/zvm@${ZVM_VERSION} \
+    && zvm install ${ZIG_VERSION} \
+    && zvm use ${ZIG_VERSION}
 
 WORKDIR /app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ search. The more you commit, the smarter it gets.
 
 ## Prerequisites
 
-- Zig (0.15.2)
+- Zig (0.16.0)
 - Docker Desktop (with [Model Runner][] enabled)
 - (Optional) Ollama — alternative model runner (`--runner ollama`)
 - (Optional) `psql`

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,9 @@
 const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    requirez("0.16.0");
+}
 
 // protip: run zig build --fetch if you don't have some of the remote deps for
 // this project
@@ -48,4 +53,19 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&run_exe_tests.step);
+}
+
+/// Require a specific version of Zig to build this project.
+/// https://github.com/ghostty-org/ghostty/blob/main/src/build/zig.zig
+pub fn requirez(comptime required_zig: []const u8) void {
+    const current_vsn = builtin.zig_version;
+    const required_vsn = std.SemanticVersion.parse(required_zig) catch unreachable;
+    if (current_vsn.major != required_vsn.major or
+        current_vsn.minor != required_vsn.minor)
+    {
+        @compileError(std.fmt.comptimePrint(
+            "Your Zig version v{} does not meet the required build version of v{}",
+            .{ current_vsn, required_vsn },
+        ));
+    }
 }

--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
 
@@ -20,17 +21,11 @@ pub fn build(b: *std.Build) void {
         "pg",
         b.dependency("pg", .{}).module("pg"),
     );
-    // https://github.com/karlseguin/zul
-    exe.root_module.addImport(
-        "zul",
-        b.dependency("zul", .{}).module("zul"),
-    );
 
     // https://zighelp.org/chapter-4/ or `man ld`
     // Zig (like any linker on Unix) automatically prepends lib to the name when
     // searching for the file
-    exe.linkSystemLibrary("git2");
-    exe.linkLibC();
+    exe.root_module.linkSystemLibrary("git2", .{});
 
     b.installArtifact(exe);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0xa89789cfdd52da45, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
@@ -33,12 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .pg = .{
-            .url = "git+https://github.com/karlseguin/pg.zig#e58b318b7867ef065b3135983f829219c5eef891",
-            .hash = "pg-0.0.0-Wp_7gXFoBgD0fQ72WICKa-bxLga03AXXQ3BbIsjjohQ3",
-        },
-        .zul = .{
-            .url = "https://github.com/karlseguin/zul/archive/master.tar.gz",
-            .hash = "zul-0.0.0-1oDot9yRBwDA_ovd6GC1M_ViW3LarywMaGrH6vcuEjqv",
+            .url = "git+https://github.com/karlseguin/pg.zig#95fbbf99c43aeec71bcf9b72701c03e619d61f6b",
+            .hash = "pg-0.0.0-Wp_7gViDBgDB4734XO6MhGbrvDwWTwX9lFF8Rr9-R3p7",
         },
     },
     .paths = .{

--- a/src/cmd/Flags.zig
+++ b/src/cmd/Flags.zig
@@ -31,6 +31,7 @@ git: bool,
 limit: usize,
 runner: Runner,
 allocator: std.mem.Allocator,
+io: std.Io,
 
 pub fn deinit(self: Flags) void {
     self.allocator.free(self.target);
@@ -65,23 +66,22 @@ pub const usage =
     \\  --runner      local model runner to use (default: docker)
 ;
 
-pub fn init(allocator: std.mem.Allocator) !Flags {
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+pub fn init(allocator: std.mem.Allocator, process_init: std.process.Init) !Flags {
+    const args = try process_init.minimal.args.toSlice(process_init.arena.allocator());
 
     if (args.len < 2) {
         help();
-        std.posix.exit(1);
+        std.process.exit(1);
     }
 
     if (std.mem.eql(u8, args[1], "--help")) {
         help();
-        std.posix.exit(0);
+        std.process.exit(0);
     }
 
     const cmd = std.meta.stringToEnum(IshiCmd, args[1]) orelse {
         help();
-        std.posix.exit(1);
+        std.process.exit(1);
     };
 
     // Parse --key value pairs and boolean flags from args[2..]
@@ -101,7 +101,7 @@ pub fn init(allocator: std.mem.Allocator) !Flags {
         const arg = args[i];
         if (std.mem.eql(u8, arg, "--help")) {
             help();
-            std.posix.exit(0);
+            std.process.exit(0);
         } else if (std.mem.eql(u8, arg, "--git")) {
             git = true;
         } else if (std.mem.eql(u8, arg, "--target")) {
@@ -127,7 +127,7 @@ pub fn init(allocator: std.mem.Allocator) !Flags {
             if (i < args.len) {
                 limit = std.fmt.parseInt(usize, args[i], 10) catch {
                     log.err("Invalid --limit value '{s}'", .{args[i]});
-                    std.posix.exit(1);
+                    std.process.exit(1);
                 };
             }
         } else if (std.mem.eql(u8, arg, "--runner")) {
@@ -135,7 +135,7 @@ pub fn init(allocator: std.mem.Allocator) !Flags {
             if (i < args.len) {
                 runner = std.meta.stringToEnum(Runner, args[i]) orelse {
                     log.err("Unknown runner '{s}'. Supported: docker, ollama", .{args[i]});
-                    std.posix.exit(1);
+                    std.process.exit(1);
                 };
             }
         } else {
@@ -151,14 +151,14 @@ pub fn init(allocator: std.mem.Allocator) !Flags {
     // that returns a result, except it shares the surrounding scope.
     const mod = models.find(model_name) orelse blk: {
         // Model not in static list — probe the runner for dimensions.
-        const embedding = runner_mod.getEmbedding(allocator, .{
+        const embedding = runner_mod.getEmbedding(allocator, process_init.io, .{
             .text = "probe",
             .model_name = model_name,
             .runner = runner,
         }) catch {
             log.err("Unknown model '{s}' and probe failed. Known models:", .{model_name});
             for (models.models) |m| log.err("  {s}", .{m.name});
-            std.posix.exit(1);
+            std.process.exit(1);
         };
         defer allocator.free(embedding);
         log.debug("probed '{s}': {d} dims", .{ model_name, embedding.len });
@@ -187,6 +187,7 @@ pub fn init(allocator: std.mem.Allocator) !Flags {
         .limit = limit,
         .allocator = allocator,
         .runner = runner,
+        .io = process_init.io,
     };
 }
 

--- a/src/cmd/query.zig
+++ b/src/cmd/query.zig
@@ -9,13 +9,13 @@ const Flags = @import("Flags.zig");
 pub fn run(allocator: std.mem.Allocator, pool: *pg.Pool, f: Flags) !void {
     if (f.query.len == 0) {
         log.err("query text is required: ishi query \"your question here\"", .{});
-        std.posix.exit(1);
+        std.process.exit(1);
     }
 
     std.debug.print("querying: \"{s}\"\n\n", .{f.query});
 
     // Embed the query text via the model runner.
-    const embedding = try runner.getEmbedding(allocator, .{
+    const embedding = try runner.getEmbedding(allocator, f.io, .{
         .model_name = f.model.name,
         .text = f.query,
         .runner = f.runner,

--- a/src/cmd/seed.zig
+++ b/src/cmd/seed.zig
@@ -27,7 +27,7 @@ fn seedFromGit(allocator: std.mem.Allocator, pool: *pg.Pool, f: Flags) !void {
 
     const commits = git.walkCommits(allocator, ".", f.limit) catch |err| {
         log.err("Failed to walk git history: {}", .{err});
-        std.posix.exit(1);
+        std.process.exit(1);
     };
     defer {
         for (commits) |*ci| {
@@ -55,7 +55,7 @@ fn seedFromGit(allocator: std.mem.Allocator, pool: *pg.Pool, f: Flags) !void {
         const content = full_content[0..@min(full_content.len, max_embed_len)];
         log.debug("Git Embedding:\t{s}", .{content});
 
-        const embedding = runner.getEmbedding(allocator, .{
+        const embedding = runner.getEmbedding(allocator, f.io, .{
             .model_name = f.model.name,
             .text = content,
             .runner = f.runner,
@@ -80,13 +80,14 @@ fn seedFromGit(allocator: std.mem.Allocator, pool: *pg.Pool, f: Flags) !void {
 
 fn seedFromJson(allocator: std.mem.Allocator, pool: *pg.Pool, f: Flags) !void {
     // Read the seed file from disk.
-    const seed_data = std.fs.cwd().readFileAlloc(
-        allocator,
+    const seed_data = std.Io.Dir.cwd().readFileAlloc(
+        f.io,
         f.jsonpath,
-        1024 * 1024,
+        allocator,
+        std.Io.Limit.limited(1024 * 1024),
     ) catch |err| {
         log.err("Failed to read '{s}': {}", .{ f.jsonpath, err });
-        std.posix.exit(1);
+        std.process.exit(1);
     };
     defer allocator.free(seed_data);
 
@@ -104,7 +105,7 @@ fn seedFromJson(allocator: std.mem.Allocator, pool: *pg.Pool, f: Flags) !void {
         log.info("embedding '{s}'...", .{entry.id});
 
         // Call the model runner to generate the embedding vector.
-        const embedding = try runner.getEmbedding(allocator, .{
+        const embedding = try runner.getEmbedding(allocator, f.io, .{
             .model_name = f.model.name,
             .text = entry.text,
             .runner = f.runner,

--- a/src/lib/pgvector.zig
+++ b/src/lib/pgvector.zig
@@ -8,7 +8,9 @@ pub fn formatVector(allocator: std.mem.Allocator, embedding: []const f64) ![]u8 
     try vec.append(allocator, '[');
     for (embedding, 0..) |v, i| {
         if (i > 0) try vec.append(allocator, ',');
-        try vec.writer(allocator).print("{d}", .{v});
+        const s = try std.fmt.allocPrint(allocator, "{d}", .{v});
+        defer allocator.free(s);
+        try vec.appendSlice(allocator, s);
     }
     try vec.append(allocator, ']');
     return try vec.toOwnedSlice(allocator);

--- a/src/lib/retry.zig
+++ b/src/lib/retry.zig
@@ -24,6 +24,7 @@ pub const Config = struct {
 /// attempts fail the last error is returned to the caller.
 pub fn retry(
     comptime ResultT: type,
+    io: std.Io,
     config: Config,
     context: anytype,
     comptime requestFn: fn (@TypeOf(context)) anyerror!ResultT,
@@ -45,7 +46,11 @@ pub fn retry(
             log.warn("attempt {d}/{d} failed: {}, retrying in {d}ms...", .{
                 attempts, config.max_retries, err, backoff_ms,
             });
-            std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
+            const duration: std.Io.Clock.Duration = .{
+                .raw = .fromNanoseconds(@intCast(backoff_ms * std.time.ns_per_ms)),
+                .clock = .awake,
+            };
+            duration.sleep(io) catch {};
             backoff_ms = @min(backoff_ms * config.backoff_multiplier, config.max_backoff_ms);
         }
     }
@@ -55,13 +60,13 @@ pub fn retry(
 
 test "retry succeeds on first attempt" {
     const ctx = CountingContext{ .fail_n = 0 };
-    const result = try retry(u32, .{}, ctx, CountingContext.call);
+    const result = try retry(u32, std.testing.io, .{}, ctx, CountingContext.call);
     try std.testing.expectEqual(@as(u32, 42), result);
 }
 
 test "retry succeeds after transient failures" {
     const ctx = CountingContext{ .fail_n = 2 };
-    const result = try retry(u32, .{
+    const result = try retry(u32, std.testing.io, .{
         .max_retries = 4,
         .initial_backoff_ms = 0, // no sleeping in tests
     }, ctx, CountingContext.call);
@@ -70,7 +75,7 @@ test "retry succeeds after transient failures" {
 
 test "retry returns last error when exhausted" {
     const ctx = CountingContext{ .fail_n = 10 };
-    const result = retry(u32, .{
+    const result = retry(u32, std.testing.io, .{
         .max_retries = 3,
         .initial_backoff_ms = 0,
     }, ctx, CountingContext.call);

--- a/src/lib/runner.zig
+++ b/src/lib/runner.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zul = @import("zul");
 
 const Runner = @import("../cmd/Flags.zig").Runner;
 pub const log = std.log.scoped(.runner);
@@ -29,6 +28,7 @@ pub const Opts = struct {
 /// function can be passed to `retry.retry` which takes `fn(Context) !T`.
 const EmbeddingContext = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     opts: Opts,
 };
 
@@ -37,24 +37,25 @@ const EmbeddingContext = struct {
 /// failures. Caller owns the returned slice.
 pub fn getEmbedding(
     allocator: std.mem.Allocator,
+    io: std.Io,
     opts: Opts,
 ) ![]f64 {
-    const ctx = EmbeddingContext{ .allocator = allocator, .opts = opts };
+    const ctx = EmbeddingContext{ .allocator = allocator, .io = io, .opts = opts };
     return switch (opts.runner) {
-        .ollama => retry.retry([]f64, .{}, ctx, attemptOllamaEmbedding),
-        .docker => retry.retry([]f64, .{}, ctx, attemptDockerEmbedding),
+        .ollama => retry.retry([]f64, io, .{}, ctx, attemptOllamaEmbedding),
+        .docker => retry.retry([]f64, io, .{}, ctx, attemptDockerEmbedding),
     };
 }
 
 fn attemptOllamaEmbedding(ctx: EmbeddingContext) anyerror![]f64 {
-    return getOllamaEmbedding(ctx.allocator, ctx.opts);
+    return getOllamaEmbedding(ctx.allocator, ctx.io, ctx.opts);
 }
 
 fn attemptDockerEmbedding(ctx: EmbeddingContext) anyerror![]f64 {
-    return getDockerEmbedding(ctx.allocator, ctx.opts);
+    return getDockerEmbedding(ctx.allocator, ctx.io, ctx.opts);
 }
 
-fn getOllamaEmbedding(allocator: std.mem.Allocator, opts: Opts) ![]f64 {
+fn getOllamaEmbedding(allocator: std.mem.Allocator, io: std.Io, opts: Opts) ![]f64 {
     const Payload = struct { model: []const u8, prompt: []const u8 };
     const body = try buildBody(allocator, Payload, .{
         .model = opts.model_name,
@@ -63,45 +64,21 @@ fn getOllamaEmbedding(allocator: std.mem.Allocator, opts: Opts) ![]f64 {
     defer allocator.free(body);
 
     const endpoint = "http://localhost:11434/api/embeddings";
+    const response_bytes = try postJson(allocator, io, endpoint, body);
+    defer allocator.free(response_bytes);
 
-    var client = zul.http.Client.init(allocator);
-    defer client.deinit();
+    const parsed = try std.json.parseFromSlice(
+        OllamaEmbeddingResponse,
+        allocator,
+        response_bytes,
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
 
-    var req = client.request(endpoint) catch |err| {
-        log.err("Failed to create request for {s}: {}", .{ endpoint, err });
-        return err;
-    };
-    defer req.deinit();
-    req.method = .POST;
-    try req.header("Content-Type", "application/json");
-    req.body(body);
-
-    var res = req.getResponse(.{}) catch |err| {
-        log.err("Failed to POST to {s}: {}", .{ endpoint, err });
-        return err;
-    };
-
-    if (res.status != 200) {
-        const err_body = res.allocBody(allocator, .{ .max_size = 4096 }) catch |err| {
-            log.err("ollama request to {s} failed with status {d} (could not read body: {})", .{ endpoint, res.status, err });
-            return error.RunnerRequestFailed;
-        };
-        defer err_body.deinit();
-        log.err("ollama request to {s} failed with status {d}: {s}", .{
-            endpoint,
-            res.status,
-            err_body.string(),
-        });
-        return error.RunnerRequestFailed;
-    }
-
-    const managed = try res.json(OllamaEmbeddingResponse, allocator, .{});
-    defer managed.deinit();
-
-    return try allocator.dupe(f64, managed.value.embedding);
+    return try allocator.dupe(f64, parsed.value.embedding);
 }
 
-fn getDockerEmbedding(allocator: std.mem.Allocator, opts: Opts) ![]f64 {
+fn getDockerEmbedding(allocator: std.mem.Allocator, io: std.Io, opts: Opts) ![]f64 {
     const Payload = struct { model: []const u8, input: []const u8 };
     const body = try buildBody(allocator, Payload, .{
         .model = opts.model_name,
@@ -110,49 +87,62 @@ fn getDockerEmbedding(allocator: std.mem.Allocator, opts: Opts) ![]f64 {
     defer allocator.free(body);
 
     const endpoint = "http://localhost:12434/engines/llama.cpp/v1/embeddings";
+    const response_bytes = try postJson(allocator, io, endpoint, body);
+    defer allocator.free(response_bytes);
 
-    var client = zul.http.Client.init(allocator);
-    defer client.deinit();
+    const parsed = try std.json.parseFromSlice(
+        OpenAIEmbeddingResponse,
+        allocator,
+        response_bytes,
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
 
-    var req = client.request(endpoint) catch |err| {
-        log.err("Failed to create request for {s}: {}", .{ endpoint, err });
-        return err;
-    };
-    defer req.deinit();
-    req.method = .POST;
-    try req.header("Content-Type", "application/json");
-    req.body(body);
-
-    var res = req.getResponse(.{}) catch |err| {
-        log.err("Failed to POST to {s}: {}", .{ endpoint, err });
-        return err;
-    };
-
-    if (res.status != 200) {
-        const err_body = res.allocBody(allocator, .{ .max_size = 4096 }) catch |err| {
-            log.err("docker request to {s} failed with status {d} (could not read body: {})", .{ endpoint, res.status, err });
-            return error.RunnerRequestFailed;
-        };
-        defer err_body.deinit();
-        log.err("docker request to {s} failed with status {d}: {s}", .{
-            endpoint,
-            res.status,
-            err_body.string(),
-        });
-        return error.RunnerRequestFailed;
-    }
-
-    const managed = try res.json(OpenAIEmbeddingResponse, allocator, .{
-        .ignore_unknown_fields = true,
-    });
-    defer managed.deinit();
-
-    if (managed.value.data.len == 0) {
+    if (parsed.value.data.len == 0) {
         log.err("docker response contained no embedding data", .{});
         return error.RunnerRequestFailed;
     }
 
-    return try allocator.dupe(f64, managed.value.data[0].embedding);
+    return try allocator.dupe(f64, parsed.value.data[0].embedding);
+}
+
+/// POSTs `body` as JSON to `endpoint` and returns the raw response body.
+/// Caller owns the returned slice. Returns `error.RunnerRequestFailed` on
+/// non-2xx responses (logging the status + body for diagnosis).
+fn postJson(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    endpoint: []const u8,
+    body: []const u8,
+) ![]u8 {
+    var client: std.http.Client = .{ .allocator = allocator, .io = io };
+    defer client.deinit();
+
+    var response_buf: std.Io.Writer.Allocating = .init(allocator);
+    defer response_buf.deinit();
+
+    const result = client.fetch(.{
+        .location = .{ .url = endpoint },
+        .method = .POST,
+        .payload = body,
+        .headers = .{ .content_type = .{ .override = "application/json" } },
+        .response_writer = &response_buf.writer,
+    }) catch |err| {
+        log.err("Failed to POST to {s}: {}", .{ endpoint, err });
+        return err;
+    };
+
+    const status_int = @intFromEnum(result.status);
+    if (status_int < 200 or status_int >= 300) {
+        log.err("request to {s} failed with status {d}: {s}", .{
+            endpoint,
+            status_int,
+            response_buf.written(),
+        });
+        return error.RunnerRequestFailed;
+    }
+
+    return response_buf.toOwnedSlice();
 }
 
 /// Serializes a struct value to a JSON byte string. Caller owns the result.

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,21 +32,19 @@ pub const std_options: std.Options = .{
     .log_level = .info,
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer std.debug.assert(gpa.deinit() == .ok);
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
-    const f = try Flags.init(allocator);
+    const f = try Flags.init(allocator, init);
     defer f.deinit();
 
-    var pool = pg.Pool.init(allocator, .{
+    var pool = pg.Pool.init(init.io, allocator, .{
         .size = 1,
         .connect = .{ .host = f.target, .port = 5432 },
         .auth = .{ .username = f.username, .password = f.password, .database = f.database },
     }) catch |err| {
         log.err("Failed to connect to {s}(is the db running?): {}", .{ f.target, err });
-        std.posix.exit(1);
+        std.process.exit(1);
     };
     defer pool.deinit();
 


### PR DESCRIPTION
## Summary
- Adopts the 0.16.0 `pub fn main(init: std.process.Init)` signature; drops the hand-rolled GPA in favor of `init.gpa` / `init.arena` / `init.io`.
- Replaces `zul` (incompatible with 0.16.0 — uses the removed `@Type` builtin) with `std.http.Client` + `Io.Writer.Allocating`; bumps `pg.zig` to `95fbbf9` for its 0.16.0 fix.
- Migrates all writergate / `Io` API churn: `linkSystemLibrary` onto the Module, `std.Thread.sleep` → `Io.Clock.Duration.sleep`, `std.fs.cwd().readFileAlloc` → `Io.Dir.cwd().readFileAlloc(io, …, Io.Limit)`, `std.posix.exit` → `std.process.exit`, `ArrayList.writer` → `allocPrint` + `appendSlice`.
- Scopes CI `zig fmt --check` to our own paths so the 0.16.0 `zig-pkg/` dep cache doesn't fail the check.

## Test plan
- [x] `zig build` succeeds locally on Zig 0.16.0
- [x] `zig build test --summary all` — 6/6 pass
- [x] `zig fmt --check src build.zig build.zig.zon` — clean
- [ ] CI on this PR goes green
- [ ] Smoke test end-to-end: `ishi --help`, then one `query` (exercises `runner.zig` / `std.http.Client`) and one `seed` (exercises `pgvector.zig` writergate site) against a local Postgres