### PR TITLE
feat: hybrid BM25 + cosine search with RRF fusion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache build-base libgit2-dev go \
 
 WORKDIR /app
 COPY . .
-RUN zig build
+RUN --mount=type=cache,target=/root/.cache/zig zig build
 
 CMD [ "/app/zig-out/bin/ishi", "init", \
     "--target", "vdb", "--git", \

--- a/src/cmd/init.zig
+++ b/src/cmd/init.zig
@@ -17,16 +17,22 @@ const table =
     \\ commit_date TIMESTAMPTZ,
     \\ files_changed INT,
     \\ insertions INT,
-    \\ deletions INT);
+    \\ deletions INT,
+    \\ textsearch tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED);
+;
+
+const textsearch_index =
+    \\CREATE INDEX IF NOT EXISTS items_textsearch_idx ON items USING GIN (textsearch);
 ;
 
 pub fn run(_: std.mem.Allocator, pool: *pg.Pool, f: Flags) !void {
     _ = try pool.exec("CREATE EXTENSION IF NOT EXISTS vector;", .{});
 
     // DDL cannot use query parameters — build the SQL on the stack.
-    var buf: [512]u8 = undefined;
+    var buf: [1024]u8 = undefined;
     const create_table = try std.fmt.bufPrint(&buf, table, .{f.model.dims});
     _ = try pool.exec(create_table, .{});
+    _ = try pool.exec(textsearch_index, .{});
 
     std.debug.print("initialized for model '{s}' ({d} dims)\n", .{
         f.model.name, f.model.dims,

--- a/src/cmd/query.zig
+++ b/src/cmd/query.zig
@@ -26,18 +26,34 @@ pub fn run(allocator: std.mem.Allocator, pool: *pg.Pool, f: Flags) !void {
     const vec_str = try pgvector.formatVector(allocator, embedding);
     defer allocator.free(vec_str);
 
-    // Find the 3 most semantically similar items using cosine distance.
+    // Hybrid search: combine vector (cosine) and BM25 (tsvector) results
+    // via Reciprocal Rank Fusion. k=60 follows the pgvector README default.
     var result = try pool.query(
-        \\SELECT content, 1 - (embedding <=> $1::vector) AS similarity
-        \\FROM items ORDER BY embedding <=> $1::vector LIMIT 3
-    , .{vec_str});
+        \\WITH semantic_search AS (
+        \\    SELECT id, RANK() OVER (ORDER BY embedding <=> $1::vector) AS rank
+        \\    FROM items ORDER BY embedding <=> $1::vector LIMIT 20
+        \\),
+        \\keyword_search AS (
+        \\    SELECT id, RANK() OVER (ORDER BY ts_rank_cd(textsearch, query) DESC) AS rank
+        \\    FROM items, plainto_tsquery('english', $2) query
+        \\    WHERE textsearch @@ query
+        \\    ORDER BY ts_rank_cd(textsearch, query) DESC LIMIT 20
+        \\)
+        \\SELECT i.content,
+        \\       COALESCE(1.0 / (60 + ss.rank), 0.0)
+        \\     + COALESCE(1.0 / (60 + ks.rank), 0.0) AS score
+        \\FROM semantic_search ss
+        \\FULL OUTER JOIN keyword_search ks ON ss.id = ks.id
+        \\JOIN items i ON i.id = COALESCE(ss.id, ks.id)
+        \\ORDER BY score DESC LIMIT 3
+    , .{ vec_str, f.query });
     defer result.deinit();
 
     var rank: u8 = 1;
     while (try result.next()) |row| {
         const content = try row.get([]const u8, 0);
-        const similarity = try row.get(f64, 1);
-        std.debug.print("{d}. ({d:.4}) {s}\n", .{ rank, similarity, content });
+        const score = try row.get(f64, 1);
+        std.debug.print("{d}. ({d:.4}) {s}\n", .{ rank, score, content });
         rank += 1;
     }
 


### PR DESCRIPTION
## Summary

- Adds a generated `textsearch tsvector` column + GIN index to the items schema in `src/cmd/init.zig`.
- Replaces the cosine-only query in `src/cmd/query.zig` with a Reciprocal Rank Fusion CTE that combines vector search (`embedding <=> $1`) with PostgreSQL full-text search (`ts_rank_cd`), following the pgvector README pattern.
- Each side returns top 20 by rank; the outer query sums `1/(60+rank)` contributions and returns the top 3.

Closes #18.

## Why

`ishi query "comptime"` previously surfaced loosely related Ollama/cosine-similarity commits because they were nearby in embedding space — exact-token matches were ignored. Hybrid search respects rare/exact tokens while preserving semantic recall when there are no exact hits.

## Notes

- The `textsearch` column is `GENERATED ALWAYS AS (to_tsvector('english', content)) STORED`, so seed code paths didn't need to change.
- No migration framework exists in ishi, and `init.zig` uses `CREATE TABLE IF NOT EXISTS`. **Existing databases will NOT auto-upgrade** — users must drop the items table and re-run `ishi init` + `ishi seed`.
- RRF `k=60` and per-side `LIMIT 20` follow pgvector's documented defaults; tuning is left for follow-up if needed.
- `'english'` language is hardcoded; configurability is out of scope here.

## Test plan

- [x] `zig build` passes
- [x] Dropped items table, ran `ishi init`, verified schema includes `textsearch tsvector` + `items_textsearch_idx` GIN index
- [x] Ran `ishi seed` against local git history (50 commits seeded cleanly)
- [x] `ishi query "comptime"` ranks the commit literally containing "comptime" first (was previously buried by semantically-similar but token-less results)
- [x] `ishi query "how does embedding work"` still returns semantic results when no exact-token hits exist (FULL OUTER JOIN path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)